### PR TITLE
Feat: igraph.Graph() support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 ## Get latest from https://github.com/github/gitignore/blob/main/VisualStudio.gitignore
 
 # User-specific files
+temp.py
 *.png
 *.csv
 .ignore

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,17 +3,15 @@
 //! Copyright 2025 - Guilherme Santos. If a copy of the MPL was not distributed with this
 //! file, You can obtain one at https://www.gnu.org/licenses/gpl-3.0.html
 
-use crate::graph::*;
-
-use std::collections::{BTreeMap, HashMap};
-
+use crate::{debug, graph::*};
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyDict};
+use std::collections::{BTreeMap, HashMap};
 
 pub fn normalize_community_ids(partition: Partition) -> Partition {
-    let mut new_partition = Partition::new();
-    let mut id_mapping = HashMap::new();
-    let mut next_id = 0;
+    let mut new_partition: BTreeMap<i32, i32> = Partition::new();
+    let mut id_mapping: HashMap<i32, i32> = HashMap::new();
+    let mut next_id: i32 = 0;
 
     // Create a new mapping for community IDs
     for (node_id, &community_id) in partition.iter() {
@@ -26,35 +24,48 @@ pub fn normalize_community_ids(partition: Partition) -> Partition {
 
     new_partition
 }
-
-/// Convert Python dict to Rust partition
-#[allow(dead_code)]
 pub fn to_partition(py_dict: &Bound<'_, PyDict>) -> PyResult<Partition> {
-    let mut part = BTreeMap::new();
+    let mut part: BTreeMap<i32, i32> = BTreeMap::new();
     for (node, comm) in py_dict.iter() {
         part.insert(node.extract::<NodeId>()?, comm.extract::<CommunityId>()?);
     }
     Ok(part)
 }
-
-/// Get edges from NetworkX graph
+/// Try NetworkX's `edges()` first. If that fails, fall back to igraph's `get_edgelist()`.
 pub fn get_edges(graph: &Bound<'_, PyAny>) -> PyResult<Vec<(NodeId, NodeId)>> {
-    let mut edges = Vec::new();
-    let edges_iter = graph.call_method0("edges")?.call_method0("__iter__")?;
-
-    for edge in edges_iter.try_iter()? {
-        let edge = edge?;
-        let from = edge.get_item(0)?.extract()?;
-        let to = edge.get_item(1)?.extract()?;
+    let edges_iter = match graph.call_method0("edges") {
+        Ok(nx_edges) => {
+            // NetworkX: `edges()` returns an EdgeView; get its iterator
+            nx_edges.call_method0("__iter__")?
+        }
+        Err(_) => {
+            debug!(warn, "networkx.Graph() not found, trying igraph.Graph()");
+            match graph.call_method0("get_edgelist") {
+                Ok(ig_edges) => {
+                    // igraph: `get_edgelist()` returns a list of edge tuples; get its iterator
+                    ig_edges.call_method0("__iter__")?
+                }
+                Err(_) => {
+                    debug!(err, "supported graph libraries not found");
+                    return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                        "neither NetworkX nor igraph graph methods are available",
+                    ));
+                }
+            }
+        }
+    };
+    let mut edges: Vec<(NodeId, NodeId)> = Vec::new();
+    for edge_obj in edges_iter.try_iter()? {
+        let edge: Bound<'_, PyAny> = edge_obj?;
+        let from: NodeId = edge.get_item(0)?.extract()?;
+        let to: NodeId = edge.get_item(1)?.extract()?;
         edges.push((from, to));
     }
 
     Ok(edges)
 }
-
-/// Build Graph from edges
 pub fn build_graph(edges: Vec<(NodeId, NodeId)>) -> Graph {
-    let mut graph = Graph::new();
+    let mut graph: Graph = Graph::new();
     for (from, to) in edges {
         graph.add_edge(from, to);
     }

--- a/unit_tests/test.py
+++ b/unit_tests/test.py
@@ -1,0 +1,104 @@
+import unittest
+import networkx as nx
+import pymocd
+import random
+import igraph as ig
+
+def build_two_clique_graph():
+    G = nx.Graph()
+    G.add_nodes_from(range(6))
+    G.add_edges_from([(0, 1), (0, 2), (1, 2)])
+    G.add_edges_from([(3, 4), (3, 5), (4, 5)])
+    G.add_edge(2, 3)
+    return G
+
+class TestPyMoCDNetworkX(unittest.TestCase):
+    def test_simple_two_clique_partition(self):
+        G = build_two_clique_graph()
+        alg = pymocd.HpMocd(G, debug_level=0)
+        communities = alg.run()
+
+        unique_labels = set(communities.values())
+        self.assertEqual(len(unique_labels), 2)
+
+        comm_to_nodes = {}
+        for node, cid in communities.items():
+            comm_to_nodes.setdefault(cid, set()).add(node)
+
+        sorted_parts = tuple(
+            sorted(tuple(sorted(nodes)) for nodes in comm_to_nodes.values())
+        )
+        self.assertEqual(sorted_parts, ((0, 1, 2), (3, 4, 5)))
+
+    def test_empty_graph_returns_empty_dict_or_error(self):
+        G_empty = nx.Graph()
+        alg = pymocd.HpMocd(G_empty, debug_level=0)
+        try:
+            communities = alg.run()
+            self.assertIsInstance(communities, dict)
+            self.assertEqual(communities, {})
+        except Exception as e:
+            self.assertIsInstance(e, Exception)
+
+    def test_non_networkx_input_raises_type_error(self):
+        not_a_graph = 12345
+        with self.assertRaises(Exception):
+            alg = pymocd.HpMocd(not_a_graph, debug_level=0)
+            alg.run()
+
+    def test_reproducibility_on_small_random_graph(self):
+        random.seed(42)
+        G_rand = nx.gnm_random_graph(n=10, m=15, seed=42)
+
+        alg1 = pymocd.HpMocd(G_rand, debug_level=0)
+        part1 = alg1.run()
+
+        random.seed(42)
+        G_rand_again = nx.gnm_random_graph(n=10, m=15, seed=42)
+
+        alg2 = pymocd.HpMocd(G_rand_again, debug_level=0)
+        part2 = alg2.run()
+
+        self.assertEqual(part1, part2)
+
+class TestPyMoCDIgraph(unittest.TestCase):
+    def test_simple_two_clique_partition(self):
+        g = build_two_clique_graph()
+        alg = pymocd.HpMocd(g, debug_level=0)
+        communities = alg.run()
+        unique_labels = set(communities.values())
+        self.assertEqual(len(unique_labels), 2)
+
+        comm_to_nodes = {}
+        for node, cid in communities.items():
+            comm_to_nodes.setdefault(cid, set()).add(node)
+        sorted_parts = sorted([tuple(sorted(list(s))) for s in comm_to_nodes.values()])
+        self.assertEqual(tuple(sorted_parts), ((0,1,2), (3,4,5)))
+
+    def test_empty_graph_returns_empty_dict_or_error(self):
+        g_empty = ig.Graph()
+        alg = pymocd.HpMocd(g_empty, debug_level=0)
+        try:
+            communities = alg.run()
+            self.assertIsInstance(communities, dict)
+            self.assertEqual(communities, {})
+        except Exception as e:
+            self.assertIsInstance(e, Exception)
+
+    def test_non_igraph_input_raises_type_error(self):
+        not_a_graph = 12345
+        with self.assertRaises(Exception):
+            alg = pymocd.HpMocd(not_a_graph, debug_level=0)
+            alg.run()
+
+    def test_reproducibility_on_small_random_graph(self):
+        random.seed(42)
+        g = ig.Graph.Erdos_Renyi(n=10, m=15, directed=False, loops=False)
+        alg1 = pymocd.HpMocd(g, debug_level=0)
+        part1 = alg1.run()
+        alg2 = pymocd.HpMocd(g, debug_level=0)
+        part2 = alg2.run()
+        self.assertEqual(part1, part2)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This closes #6.

- 4bc8b04713220562b98fd8a27a149d042e3c027c: Run igraph.Graph object to get the networkx structure
- 3a56b256ae69e83d53341e4e9210497136d4687c: Add unit_test for python using unittest `module`.