### PR TITLE
ci: node 24 actions, PR-only tests, benchmark plots in docs (#53)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,20 +6,76 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
 concurrency:
-  group: docs
-  cancel-in-progress: true
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  benchmarks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: res/requirements.txt
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Generate type stubs from Rust sources
+        run: cargo run --no-default-features --bin stub_gen
+
+      - name: Install benchmark dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r res/requirements.txt
+
+      - name: Build and install pymocd
+        run: pip install .
+
+      - name: Run bounded benchmark suite
+        working-directory: benchmarks
+        env:
+          BENCHMARK_RUN_ID: docs
+          MPLBACKEND: Agg
+          PYMOCD_BENCH_RUNS: "1"
+          PYMOCD_BENCH_MUS: "0.1,0.3,0.5,0.7"
+          PYMOCD_BENCH_NODES: "500"
+          PYMOCD_BENCH_SKIP_NODES: "1"
+        run: |
+          python -m _exp_real_net
+          python -m _exp_synt_net
+          python -m alg_params.num_generations
+          python -m alg_params.pareto_front
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-results
+          path: benchmarks/results/
+          if-no-files-found: error
+
+  deploy:
+    needs: benchmarks
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip
@@ -36,8 +92,63 @@ jobs:
       - name: Install docs dependencies
         run: pip install -r docs/requirements.txt
 
-      - name: Deploy to GitHub Pages
+      - name: Download benchmark results
+        uses: actions/download-artifact@v8
+        with:
+          name: benchmark-results
+          path: benchmark-results
+
+      - name: Copy benchmark plots into docs tree
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          mkdocs gh-deploy --force
+          run_dir=$(find benchmark-results -mindepth 1 -maxdepth 1 -type d -print -quit)
+          test -n "$run_dir"
+          dest=docs/assets/benchmarks
+          mkdir -p "$dest"
+          cp -r "$run_dir/real_nets" "$dest/"
+          cp -r "$run_dir/mu" "$dest/"
+          cp "$run_dir"/lfr_mu.csv "$run_dir"/lfr_mu_bk.csv "$dest/"
+          cp "$run_dir"/community_evolution_overview.* "$dest/"
+          cp "$run_dir"/communities_gen_*.* "$dest/"
+          cp "$run_dir"/pareto_frontier_analysis.* "$dest/"
+          cp "$run_dir"/pareto_front_plot.* "$dest/"
+          for f in \
+            real_nets/real_nets.csv \
+            real_nets/real_nets_modularity.svg \
+            real_nets/real_nets_nmi.svg \
+            real_nets/real_nets_ami.svg \
+            real_nets/real_nets_time.svg \
+            lfr_mu.csv \
+            mu/nmi_plot.svg \
+            mu/ami_plot.svg \
+            mu/modularity_plot.svg \
+            mu/time_plot.svg \
+            mu/comparison_matrix.svg \
+            mu/performance_scorecard.svg \
+            community_evolution_overview.svg \
+            communities_gen_10.svg \
+            communities_gen_30.svg \
+            communities_gen_50.svg \
+            communities_gen_80.svg \
+            communities_gen_100.svg \
+            communities_gen_110.svg \
+            pareto_frontier_analysis.svg \
+            pareto_front_plot.svg; do
+            test -f "$dest/$f"
+          done
+
+      - name: Build site
+        run: mkdocs build
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v6
+        with:
+          enablement: true
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,9 +1,6 @@
 name: Python unittest
 
 on:
-  push:
-    branches:
-      - '**'
   pull_request:
     branches:
       - '**'
@@ -14,10 +11,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: '3.10'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -64,14 +64,14 @@ jobs:
           ls -l target/wheels/
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.os }}-${{ matrix.python-version }}
           path: target/wheels/*.whl
 
       - name: Upload sdist
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sdist
           path: target/wheels/*.tar.gz
@@ -89,7 +89,7 @@ jobs:
         run: mkdir -p dist
 
       - name: Download all wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: downloaded
 
@@ -101,7 +101,7 @@ jobs:
         run: ls -l dist/
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,8 @@
 name: Rust
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "master" ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/benchmarks/_exp_synt_net/__main__.py
+++ b/benchmarks/_exp_synt_net/__main__.py
@@ -6,13 +6,22 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from .runner import ExperimentRunner
 from .constants import NUM_RUNS
 
+
+def _env_list(name, default, cast):
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return [cast(item) for item in raw.split(",") if item.strip()]
+
+
 if __name__ == "__main__":
     runner = ExperimentRunner(n_runs=NUM_RUNS)
     runner.run_mu_experiment(
-        mus=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6],
-        n_nodes_list=[10_000, 50_000],
+        mus=_env_list("PYMOCD_BENCH_MUS", [0.1, 0.2, 0.3, 0.4, 0.5, 0.6], float),
+        n_nodes_list=_env_list("PYMOCD_BENCH_NODES", [10_000, 50_000], int),
     )
-    runner.run_nodes_experiment(
-        n_list=[10_000, 25_000, 50_000, 100_000],
-        mus=[0.3, 0.5],
-    )
+    if not os.environ.get("PYMOCD_BENCH_SKIP_NODES"):
+        runner.run_nodes_experiment(
+            n_list=[10_000, 25_000, 50_000, 100_000],
+            mus=[0.3, 0.5],
+        )

--- a/benchmarks/_exp_synt_net/constants.py
+++ b/benchmarks/_exp_synt_net/constants.py
@@ -1,7 +1,9 @@
+import os
+
 MIN_MU = 0.1
 MAX_MU = 0.7
 STP_MU = 0.1
 NUM_ND = 1_000
 
-NUM_RUNS = 2
+NUM_RUNS = int(os.environ.get("PYMOCD_BENCH_RUNS", "2"))
 DEBUG = True

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,140 @@
+# Benchmarks
+
+Every documentation deployment re-runs a bounded benchmark suite in CI and
+regenerates the figures on this page. Three experiment types are included:
+a **synthetic LFR sweep** over the mixing parameter *μ*, a comparison on
+**real networks** with well-known community structure, and two
+**algorithm parameter** studies (number of generations and Pareto fronts).
+The CI workload is deliberately reduced — fewer runs and smaller graphs than
+the full local suite (`make benchmark`) — so read these plots as indicative
+trends rather than publication-grade numbers. Each figure is also exported as
+PNG and PDF next to the embedded SVG under `assets/benchmarks/`.
+
+## Real networks
+
+All detectors run on Zachary's Karate Club, Les Misérables, and the
+Florentine families graphs, averaged over repeated seeds. Raw data:
+[real_nets.csv](assets/benchmarks/real_nets/real_nets.csv).
+
+### Modularity
+
+![Modularity on real networks](assets/benchmarks/real_nets/real_nets_modularity.svg)
+
+Higher bars mean a stronger community structure found on that network; error bars show the spread across seeds.
+
+### NMI
+
+![NMI on real networks](assets/benchmarks/real_nets/real_nets_nmi.svg)
+
+Normalized mutual information against the known ground truth (only networks with labels appear); closer to 1 is a closer match.
+
+### AMI
+
+![AMI on real networks](assets/benchmarks/real_nets/real_nets_ami.svg)
+
+Adjusted mutual information corrects NMI for chance agreement, so it is the stricter of the two label-recovery scores.
+
+### Runtime
+
+![Runtime on real networks](assets/benchmarks/real_nets/real_nets_time.svg)
+
+Wall-clock seconds per detection on a log scale; lower bars are faster.
+
+## Synthetic LFR sweep
+
+Each detector runs across LFR benchmark graphs with increasing mixing
+parameter *μ* (higher *μ* means blurrier, harder-to-detect communities).
+Raw data: [lfr_mu.csv](assets/benchmarks/lfr_mu.csv), with an incremental
+backup in [lfr_mu_bk.csv](assets/benchmarks/lfr_mu_bk.csv).
+
+### Comparison matrix
+
+![Comparison matrix](assets/benchmarks/mu/comparison_matrix.svg)
+
+All four metrics side by side per algorithm and *μ*; scan a row to see how gracefully each detector degrades as mixing increases.
+
+### Performance scorecard
+
+![Performance scorecard](assets/benchmarks/mu/performance_scorecard.svg)
+
+An aggregate ranking across the sweep; higher composite scores mean better overall quality/runtime trade-offs.
+
+### NMI vs μ
+
+![NMI vs mu](assets/benchmarks/mu/nmi_plot.svg)
+
+Ground-truth recovery as communities blur; flatter curves that stay high are more robust detectors.
+
+### AMI vs μ
+
+![AMI vs mu](assets/benchmarks/mu/ami_plot.svg)
+
+The chance-adjusted counterpart of the NMI curve; it penalizes trivially fragmented or merged partitions.
+
+### Modularity vs μ
+
+![Modularity vs mu](assets/benchmarks/mu/modularity_plot.svg)
+
+Modularity of the returned partition; it naturally decreases with *μ* since the planted structure itself weakens.
+
+### Runtime vs μ
+
+![Runtime vs mu](assets/benchmarks/mu/time_plot.svg)
+
+Detection time across the sweep; watch for algorithms whose cost grows as communities get harder to separate.
+
+## Algorithm parameters
+
+### Community evolution across generations
+
+![Community evolution overview](assets/benchmarks/community_evolution_overview.svg)
+
+Six snapshots of the same LFR graph as `pymocd.scale` runs for more generations; colors are communities, so watch fragmented labels consolidate into the planted structure.
+
+### Generation 10
+
+![Communities at generation 10](assets/benchmarks/communities_gen_10.svg)
+
+The earliest snapshot: the population has barely evolved, so partitions are still noisy and over-fragmented.
+
+### Generation 30
+
+![Communities at generation 30](assets/benchmarks/communities_gen_30.svg)
+
+Small fragments begin merging as selection pressure favors coherent groups.
+
+### Generation 50
+
+![Communities at generation 50](assets/benchmarks/communities_gen_50.svg)
+
+The dominant communities are recognizable, with disagreement left mostly at the boundaries.
+
+### Generation 80
+
+![Communities at generation 80](assets/benchmarks/communities_gen_80.svg)
+
+Refinement stage: boundary nodes settle and community counts stabilize.
+
+### Generation 100
+
+![Communities at generation 100](assets/benchmarks/communities_gen_100.svg)
+
+Close to convergence; compare with generation 110 to judge whether extra generations still pay off.
+
+### Generation 110
+
+![Communities at generation 110](assets/benchmarks/communities_gen_110.svg)
+
+The final snapshot; if it is indistinguishable from generation 100, the run has converged.
+
+### Pareto front
+
+![Pareto front](assets/benchmarks/pareto_front_plot.svg)
+
+Each point is one non-dominated partition in intra/inter objective space, colored by its Q score; the star marks the max-Q solution the API returns.
+
+### Pareto frontier analysis
+
+![Pareto frontier analysis](assets/benchmarks/pareto_frontier_analysis.svg)
+
+The same front alongside how Q relates to community count, modularity, NMI, and AMI; the dashed line marks the selected solution's Q in every panel.

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,3 +1,4 @@
+import re
 import shutil
 from pathlib import Path
 
@@ -10,7 +11,14 @@ def on_startup(command, dirty):
         raise FileNotFoundError("pymocd.pyi not found — run `make stubs` first")
     dest = ROOT / ".docs-stub"
     dest.mkdir(exist_ok=True)
-    shutil.copy(stub, dest / "pymocd.py")
+    text = stub.read_text()
+    text = re.sub(
+        r"def __new__\(cls(.*)\) -> [\w.]+:( \.\.\.)?$",
+        r"def __init__(self\1) -> None:\2",
+        text,
+        flags=re.M,
+    )
+    (dest / "pymocd.py").write_text(text)
 
     assets = ROOT / "docs" / "assets"
     assets.mkdir(exist_ok=True)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
   - Home: index.md
   - Getting started: getting-started.md
   - Algorithms: algorithms.md
+  - Benchmarks: benchmarks.md
   - Examples:
       - Plotting communities: examples/plotting.md
       - Custom objectives: examples/custom-objectives.md


### PR DESCRIPTION
Pages now deploys through actions/deploy-pages instead of mkdocs gh-deploy, so the managed pages workflow that emitted the Node 20 deprecation stops running (requires flipping the Pages source to GitHub Actions in repo settings). Every action across docs, python, rust and release workflows is bumped to its Node 24 major. Unit test workflows trigger on pull requests only; rust.yml also targeted a nonexistent main branch and never ran. The docs pipeline gains a benchmarks job that runs a bounded suite (env-capped LFR sweep, real networks, generations, pareto front) and publishes the plots on a new Benchmarks page.