### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/oliveira-sh/pymocd/security/code-scanning/8](https://github.com/oliveira-sh/pymocd/security/code-scanning/8)

Add an explicit `permissions` block to `.github/workflows/rust.yml` so the workflow token is least-privileged.  
Best fix here: define workflow-level permissions directly under `on` (or before `jobs`) with `contents: read`, since all jobs in this workflow are read-only (checkout/build/test) and do not require write scopes.

Change needed:
- File: `.github/workflows/rust.yml`
- Insert:
  - `permissions:`
  - `  contents: read`
- No imports, methods, or external definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
